### PR TITLE
Fix: 로그아웃 상태 시 게시글이 불러와지지 않는 오류 수정

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -25,18 +25,15 @@ user.interceptors.request.use(
     if (token) {
       config.headers.common['Authorization'] = `Bearer ${token}`;
     }
-    console.log('인터셉터 config => ', config);
     return config;
   },
   error => {
-    console.log('인터셉터 request 에러 => ', error);
     return Promise.reject(error);
   }
 );
 
 user.interceptors.response.use(
   response => {
-    console.log('인터셉터 => ', response);
     return response;
   },
   error => {

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -5,13 +5,17 @@ import { useNavigate } from 'react-router-dom';
 
 const API_URL = process.env.REACT_APP_SERVER_URL;
 
-export const api = axios.create({
+export const fetchBoard = axios.create({
+  baseURL: API_URL,
+});
+
+export const authBoard = axios.create({
   baseURL: API_URL,
   headers: { Authorization: `Bearer ${Cookies.get('token')}` },
 });
 
 export const user = axios.create({
-  baseURL: API_URL, //백엔드 서버 들어올 예정
+  baseURL: API_URL,
 });
 
 user.interceptors.request.use(

--- a/src/component/board/Detail.jsx
+++ b/src/component/board/Detail.jsx
@@ -41,10 +41,10 @@ const Detail = () => {
     <DetailWrapper>
       <Container>
         <ContentWrapper>
-          <Image src={post.imgurl || noImg} alt="puppy" />
+          <Image src={post.img || noImg} alt="puppy" />
           <Info>
             <Title>{post.title}</Title>
-            <NickName>{post.nickname}</NickName>
+            <NickName>{post.username}</NickName>
             <Area>{post.address}</Area>
             <Description>{post.content}</Description>
           </Info>

--- a/src/component/board/Post.jsx
+++ b/src/component/board/Post.jsx
@@ -14,7 +14,7 @@ const Post = ({ post }) => {
           src="/assets/images/board/puppy1.jpg"
           alt="강아지이미지"
         /> */}
-        <Image src={post.imgurl || noImg} alt="puppy" />
+        <Image src={post.img || noImg} alt="puppy" />
         <Info>
           <Title>{post.title}</Title>
           <Content>{post.content}</Content>

--- a/src/component/home/HomeSection03.jsx
+++ b/src/component/home/HomeSection03.jsx
@@ -22,7 +22,6 @@ const HomeSection03 = () => {
   const postList = useSelector(state => state.boards.boards).slice(0, 7);
 
   const test = useSelector(state => state.boards);
-  console.log('test! => ', test);
 
   useEffect(() => {
     dispatch(__getList());

--- a/src/redux/modules/boardsSlice.js
+++ b/src/redux/modules/boardsSlice.js
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { PATH_URL } from '../../shared/constants';
-import { api } from '../../api/axios';
+import { authBoard, fetchBoard } from '../../api/axios';
 
 const initialState = {
   boards: [],
@@ -18,7 +18,7 @@ const header = {
 //전체 조회
 export const __getList = createAsyncThunk('boards/getList', async (payload, thunkAPI) => {
   try {
-    const response = await api.get(PATH_URL.BOARD);
+    const response = await fetchBoard.get(PATH_URL.BOARD);
     console.log(response.data);
     return thunkAPI.fulfillWithValue(response.data);
   } catch (error) {
@@ -28,7 +28,7 @@ export const __getList = createAsyncThunk('boards/getList', async (payload, thun
 // 개별 상세조회
 export const __getPostById = createAsyncThunk('boards/getPostById', async (id, thunkAPI) => {
   try {
-    const response = await api.get(`${PATH_URL.BOARD}/${id}`);
+    const response = await fetchBoard.get(`${PATH_URL.BOARD}/${id}`);
     // console.log('response.data', response.data);
     return response.data;
   } catch (error) {
@@ -39,7 +39,7 @@ export const __getPostById = createAsyncThunk('boards/getPostById', async (id, t
 export const __getByAddress = createAsyncThunk('boards/getByAddress', async (payload, thunkAPI) => {
   console.log('지역은 이거다', payload);
   try {
-    const response = await api.get(`${PATH_URL.BOARD}?address=${payload}`);
+    const response = await fetchBoard.get(`${PATH_URL.BOARD}?address=${payload}`);
     // console.log('들어옴');
     console.log('response.data', response.data);
     return thunkAPI.fulfillWithValue(response.data);
@@ -52,7 +52,7 @@ export const __getByAddress = createAsyncThunk('boards/getByAddress', async (pay
 export const __createPost = createAsyncThunk('boards/createPost', async (payload, thunkAPI) => {
   // console.log('payload', payload);
   try {
-    const response = await api.post(PATH_URL.BOARD, payload, {
+    const response = await authBoard.post(PATH_URL.BOARD, payload, {
       // headers: {
       //   'Content-Type' : "multipart/form-data",
       // },
@@ -69,7 +69,7 @@ export const __updatePost = createAsyncThunk(
   'boards/updatePost',
   async ({ id, title, nickname, address, content }, thunkAPI) => {
     try {
-      const response = await api.put(`${PATH_URL.BOARD}/${id}`, {
+      const response = await authBoard.put(`${PATH_URL.BOARD}/${id}`, {
         title,
         nickname,
         address,
@@ -85,7 +85,7 @@ export const __updatePost = createAsyncThunk(
 // 삭제
 export const __deletePost = createAsyncThunk('boards/deletePost', async (id, thunkAPI) => {
   try {
-    await api.delete(`${PATH_URL.BOARD}/${id}`);
+    await authBoard.delete(`${PATH_URL.BOARD}/${id}`);
     return id;
   } catch (error) {
     return thunkAPI.rejectWithValue(error);

--- a/src/redux/modules/boardsSlice.js
+++ b/src/redux/modules/boardsSlice.js
@@ -19,7 +19,6 @@ const header = {
 export const __getList = createAsyncThunk('boards/getList', async (payload, thunkAPI) => {
   try {
     const response = await fetchBoard.get(PATH_URL.BOARD);
-    console.log(response.data);
     return thunkAPI.fulfillWithValue(response.data);
   } catch (error) {
     return thunkAPI.rejectWithValue(error);
@@ -29,7 +28,6 @@ export const __getList = createAsyncThunk('boards/getList', async (payload, thun
 export const __getPostById = createAsyncThunk('boards/getPostById', async (id, thunkAPI) => {
   try {
     const response = await fetchBoard.get(`${PATH_URL.BOARD}/${id}`);
-    // console.log('response.data', response.data);
     return response.data;
   } catch (error) {
     return thunkAPI.rejectWithValue(error);
@@ -37,11 +35,8 @@ export const __getPostById = createAsyncThunk('boards/getPostById', async (id, t
 });
 // 개별조회(지역으로) -임시
 export const __getByAddress = createAsyncThunk('boards/getByAddress', async (payload, thunkAPI) => {
-  console.log('지역은 이거다', payload);
   try {
     const response = await fetchBoard.get(`${PATH_URL.BOARD}?address=${payload}`);
-    // console.log('들어옴');
-    console.log('response.data', response.data);
     return thunkAPI.fulfillWithValue(response.data);
   } catch (error) {
     return thunkAPI.rejectWithValue(error);
@@ -57,7 +52,6 @@ export const __createPost = createAsyncThunk('boards/createPost', async (payload
       //   'Content-Type' : "multipart/form-data",
       // },
     });
-    console.log('response.data', response.data);
     // return response.data;
   } catch (error) {
     return thunkAPI.rejectWithValue(error);

--- a/src/redux/modules/commentsSlice.js
+++ b/src/redux/modules/commentsSlice.js
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { PATH_URL } from '../../shared/constants';
-import { api } from '../../api/axios';
+import { authBoard, fetchBoard } from '../../api/axios';
 
 const initialState = {
   comments: [],
@@ -12,7 +12,7 @@ const initialState = {
 export const __getList = createAsyncThunk('comments/getList', async (boardId, thunkAPI) => {
   // console.log(boardId);
   try {
-    const response = await api.get(`${PATH_URL.BOARD}/${boardId}/comments`);
+    const response = await fetchBoard.get(`${PATH_URL.BOARD}/${boardId}/comments`);
     // console.log(response.data);
     return thunkAPI.fulfillWithValue(response.data);
   } catch (error) {
@@ -38,7 +38,7 @@ export const __createComment = createAsyncThunk(
     // console.log('boardId', boardId);
     // console.log('content', content);
     try {
-      const response = await api.post(`${PATH_URL.BOARD}/${boardId}/comments`, { content });
+      const response = await authBoard.post(`${PATH_URL.BOARD}/${boardId}/comments`, { content });
       return response.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error);
@@ -51,7 +51,7 @@ export const __updateComment = createAsyncThunk(
   'comments/updateComment',
   async ({ boardId, commentId, content }, thunkAPI) => {
     try {
-      const response = await api.put(
+      const response = await authBoard.put(
         `${PATH_URL.BOARD}/${boardId}/comments/${commentId}`,
         { content },
         {
@@ -72,7 +72,7 @@ export const __deleteComment = createAsyncThunk(
     // console.log('boardId', boardId);
     // console.log('commentId', commentId);
     try {
-      await api.delete(`${PATH_URL.BOARD}/${boardId}/comments/${commentId}`);
+      await authBoard.delete(`${PATH_URL.BOARD}/${boardId}/comments/${commentId}`);
       return { boardId, commentId };
     } catch (error) {
       return thunkAPI.rejectWithValue(error);


### PR DESCRIPTION
## 개요
로그아웃 상태 시 게시글이 불러와지지 않는 오류 수정, 서버데이터에 맞게 키값 수정, 테스트코드, 주석 제거
## 작업 사항
- [src/api/axios.js] 
  - axios instance를 `fetchBoard`, `authBoard`로 분기하여 `authBoard`에만 header에 token을 부여
  - CUD 요청 시 `authBoard`, Read만 필요할 경우 `fetchBoard` 사용
- `username`, `img`와 같은 키값 서버데이터에 맞게 변경
- 필요 없는 테스트코드, 주석 제거
## 개선점
서버에서 데이터를 불러올 때 img 키값이 변경돼서 imgUrl -> img로 변경했는데, 추후 API 문서대로 바뀔 경우 다시 수정하겠습니다.