### PR TITLE
Fix/Refactor: 로그아웃 상태 시 상세 게시물 접근할 수 없는 오류 수정, loading spinner 적용, no-img 처리, 이미지 컴포넌트 분리

### DIFF
--- a/src/component/Loading.jsx
+++ b/src/component/Loading.jsx
@@ -20,11 +20,15 @@ const LoadingContainer = styled.div`
     position: fixed;
     top: 50%;
     left: 50%;
+    width: 100%;
+    height: 100%;
     transform: translate(-50%, -50%);
+    background-color: white;
 
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
   }
 
   p {

--- a/src/component/board/Detail.jsx
+++ b/src/component/board/Detail.jsx
@@ -17,7 +17,11 @@ const Detail = () => {
   const [idCheck, setIdCheck] = useState(false);
 
   const token = Cookies.get('token');
-  const tokenUsername = jwtDecode(token);
+  let tokenUsername;
+  if (token) {
+    tokenUsername = jwtDecode(token);
+  }
+  // const tokenUsername = jwtDecode(token);
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const post = useSelector(state => state.boards.post);

--- a/src/component/board/Detail.jsx
+++ b/src/component/board/Detail.jsx
@@ -65,6 +65,7 @@ const Detail = () => {
   }, [token, dispatch]);
 
   const noImg = '/images/board/no-img.jpg';
+  const handleImageError = e => (e.target.src = noImg);
 
   return (
     <DetailWrapper>
@@ -74,7 +75,7 @@ const Detail = () => {
         <DetailCommentContainer>
           <Container>
             <ContentWrapper>
-              <Image src={post.img || noImg} alt="puppy" />
+              <Image src={post.img || noImg} onError={handleImageError} alt="puppy" />
               <Info>
                 <InfoTitle>
                   <Title>{post.title}</Title>
@@ -97,8 +98,8 @@ const Detail = () => {
               <ButtonWrapper>
                 {idCheck && (
                   <>
-                <Button onClick={() => handleUpdate()}>수정하기</Button>
-                <Button onClick={() => handleDelete()}>삭제하기</Button>
+                    <Button onClick={() => handleUpdate()}>수정하기</Button>
+                    <Button onClick={() => handleDelete()}>삭제하기</Button>
                   </>
                 )}
               </ButtonWrapper>

--- a/src/component/board/List.jsx
+++ b/src/component/board/List.jsx
@@ -139,6 +139,7 @@ const StTitle = styled.span`
   font-size: 24px;
   font-weight: semi-bold;
   color: #fbae03;
+  z-index: 1;
 `;
 
 const StLabel = styled.p`

--- a/src/component/board/Post.jsx
+++ b/src/component/board/Post.jsx
@@ -6,11 +6,13 @@ import { PATH_URL } from '../../shared/constants';
 const Post = ({ post }) => {
   const noImg = '/images/board/no-img.jpg';
 
+  const handleImageError = e => (e.target.src = noImg);
+
   return (
     <PostWrapper>
       <Link to={`${PATH_URL.BOARD}/${post.id}`}>
         <Area>{post.address}</Area>
-        <Image src={post.img || noImg} alt='puppy' />
+        <Image src={post.img || noImg} onError={handleImageError} alt="puppy" />
         <Info>
           <Title>{post.title}</Title>
           <Content>{post.content}</Content>

--- a/src/component/board/Post.jsx
+++ b/src/component/board/Post.jsx
@@ -1,18 +1,14 @@
-import react from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { PATH_URL } from '../../shared/constants';
+import ImgTag from '../common/ImgTag';
 
 const Post = ({ post }) => {
-  const noImg = '/images/board/no-img.jpg';
-
-  const handleImageError = e => (e.target.src = noImg);
-
   return (
     <PostWrapper>
       <Link to={`${PATH_URL.BOARD}/${post.id}`}>
         <Area>{post.address}</Area>
-        <Image src={post.img || noImg} onError={handleImageError} alt="puppy" />
+        <ImgTag img={post.img} height="250px" />
         <Info>
           <Title>{post.title}</Title>
           <Content>{post.content}</Content>
@@ -37,11 +33,11 @@ const PostWrapper = styled.div`
   overflow: hidden;
 `;
 
-const Image = styled.img`
-  width: 100%;
-  object-fit: cover;
-  height: 250px;
-`;
+// const Image = styled.img`
+//   width: 100%;
+//   object-fit: cover;
+//   height: 250px;
+// `;
 
 const Info = styled.div`
   padding: 10px;

--- a/src/component/common/ImgTag.jsx
+++ b/src/component/common/ImgTag.jsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const ImgTag = ({ img, height }) => {
+  const noImg = '/images/board/no-img.jpg';
+  const handleImageError = e => (e.target.src = noImg);
+  return <Image src={img || noImg} onError={handleImageError} height={height} alt="puppy" />;
+};
+
+const Image = styled.img`
+  object-fit: cover;
+  width: 100%;
+  height: ${props => props.height};
+`;
+
+export default ImgTag;

--- a/src/component/home/HomeSection03.jsx
+++ b/src/component/home/HomeSection03.jsx
@@ -21,8 +21,6 @@ const HomeSection03 = () => {
   const dispatch = useDispatch();
   const postList = useSelector(state => state.boards.boards).slice(0, 7);
 
-  const test = useSelector(state => state.boards);
-
   useEffect(() => {
     dispatch(__getList());
   }, []);

--- a/src/component/home/Section03Post.jsx
+++ b/src/component/home/Section03Post.jsx
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 
 const Section03Post = ({ title, address, imgurl }) => {
   const noImgURL = '/images/board/no-img.jpg';
+  const handleImageError = e => (e.target.src = noImgURL);
 
   return (
     <PostContainer>
-      <img src={imgurl || noImgURL} alt="dog Image" />
+      <img src={imgurl || noImgURL} onError={handleImageError} alt="dog Image" />
       <TextLabelContainer>
         <h1>{title}</h1>
         <h5>{address}</h5>

--- a/src/component/home/Section03Post.jsx
+++ b/src/component/home/Section03Post.jsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components';
+import ImgTag from '../common/ImgTag';
 
 const Section03Post = ({ title, address, imgurl }) => {
-  const noImgURL = '/images/board/no-img.jpg';
-  const handleImageError = e => (e.target.src = noImgURL);
-
   return (
     <PostContainer>
-      <img src={imgurl || noImgURL} onError={handleImageError} alt="dog Image" />
+      <ImgTag img={imgurl} height="70%" />
       <TextLabelContainer>
         <h1>{title}</h1>
         <h5>{address}</h5>
@@ -24,12 +22,6 @@ const PostContainer = styled.div`
   background-color: white;
 
   overflow: hidden;
-
-  img {
-    width: 100%;
-    height: 70%;
-    object-fit: cover;
-  }
 `;
 
 const TextLabelContainer = styled.div`

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,12 +7,15 @@ import { useState } from 'react';
 import { api } from '../api/axios';
 import Cookies from 'js-cookie';
 import jwtDecode from 'jwt-decode';
+import Loading from '../component/Loading';
 const MotionContainer = motion('div');
 const Login = () => {
   const [userInput, setUserInput] = useState({
     username: '',
     password: '',
   });
+  const [isLoading, setIsLoading] = useState(false);
+
   const navigate = useNavigate();
   const inputChange = e => {
     const { name, value } = e.target;
@@ -24,9 +27,10 @@ const Login = () => {
   const { username, password } = userInput;
   const userLogin = async () => {
     try {
+      setIsLoading(true);
       const response = await api.post(`${PATH_URL.LOGIN}`, userInput);
       // const response = await api.post('/login', userInput); //테스트용
-      console.log(response.headers.get('ACCESS_KEY'));
+      // console.log(response.headers.get('ACCESS_KEY'));
       // console.log(response);
       // const accessHeader = response.headers.get('Authorization');
 
@@ -34,15 +38,16 @@ const Login = () => {
       // console.log(accessHeader);
       const token = accessHeader.split(' ')[1];
       const userToken = jwtDecode(token);
-      console.log('tokendecode:::::::', userToken);
+      // console.log('tokendecode:::::::', userToken);
       const expirationTime = new Date(userToken.exp * 1000);
-      console.log('expirationTime::::::::', expirationTime);
+      // console.log('expirationTime::::::::', expirationTime);
       Cookies.set('token', token, { expires: expirationTime });
       setUserInput({
         username: '',
         password: '',
       });
       navigate(PATH_URL.HOME);
+      setIsLoading(false);
     } catch (error) {
       console.log(error); //통신시 키값 맞출 예정
       alert('존재하지않는 ID입니다');
@@ -58,42 +63,46 @@ const Login = () => {
       exit={{ y: -50, opacity: 0 }}
       transition={{ duration: 0.2 }}
     >
-      <LoginContainer>
-        <div>
-          <Typography variant="h4">Login</Typography>
-          <TextField
-            label="ID"
-            variant="outlined"
-            margin="dense"
-            fullWidth
-            name="username"
-            value={username || ''}
-            onChange={inputChange}
-          />
-          <TextField
-            label="Password"
-            type="password"
-            variant="outlined"
-            margin="dense"
-            fullWidth
-            name="password"
-            value={password || ''}
-            onChange={inputChange}
-          />
-          <LoginBtnWrap>
-            <div>
-              <Button variant="outlined" fullWidth onClick={userLogin}>
-                Login
-              </Button>
-            </div>
-            <div>
-              <Button variant="outlined" fullWidth onClick={goSinup}>
-                signup
-              </Button>
-            </div>
-          </LoginBtnWrap>
-        </div>
-      </LoginContainer>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <LoginContainer>
+          <div>
+            <Typography variant="h4">Login</Typography>
+            <TextField
+              label="ID"
+              variant="outlined"
+              margin="dense"
+              fullWidth
+              name="username"
+              value={username || ''}
+              onChange={inputChange}
+            />
+            <TextField
+              label="Password"
+              type="password"
+              variant="outlined"
+              margin="dense"
+              fullWidth
+              name="password"
+              value={password || ''}
+              onChange={inputChange}
+            />
+            <LoginBtnWrap>
+              <div>
+                <Button variant="outlined" fullWidth onClick={userLogin}>
+                  Login
+                </Button>
+              </div>
+              <div>
+                <Button variant="outlined" fullWidth onClick={goSinup}>
+                  signup
+                </Button>
+              </div>
+            </LoginBtnWrap>
+          </div>
+        </LoginContainer>
+      )}
     </MotionContainer>
   );
 };

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { PATH_URL } from '../shared/constants';
 import * as React from 'react';
 import FormHelperText from '@mui/material/FormHelperText';
+import Loading from '../component/Loading';
 
 import {
   TextField,
@@ -33,6 +34,7 @@ const SignUp = () => {
     password2: '',
     email: '',
   });
+  const [isLoading, setIsLoading] = useState(false);
   const { username, password, password2, email } = inputData;
 
   const changeId = e => {
@@ -95,6 +97,7 @@ const SignUp = () => {
         return;
       }
       delete inputData.password2;
+      setIsLoading(true);
       await api.post(`${PATH_URL.SIGNUP}`, inputData);
       // await api.post(`/register`, inputData); //테스트용
       inputData.password2 = '';
@@ -106,6 +109,7 @@ const SignUp = () => {
       });
       setPasswordCheck(true);
       navigate(PATH_URL.LOGIN);
+      setIsLoading(false);
     } catch (error) {
       console.log(error); //통신 시 키값 맞출예정
       // alert('중복된 ID입니다');
@@ -139,77 +143,80 @@ const SignUp = () => {
       exit={{ y: -50, opacity: 0 }}
       transition={{ duration: 0.2 }}
     >
-      <Container>
-        <div>
-          <Typography variant="h4">Sign up</Typography>
-          <Margin style={{ marginTop: 0 }}>
-            <TextField
-              label="ID"
-              helperText={usernameCheck ? ' ' : '영어,숫자로 4~12자'}
-              variant="outlined"
-              margin="normal"
-              fullWidth
-              size="small"
-              name="username"
-              value={username || ''}
-              onChange={changeId}
-            />
-          </Margin>
-          <Margin style={{ marginTop: 20 }}>
-            <FormControl variant="outlined" fullWidth>
-              <InputLabel htmlFor="outlined-adornment-password">Password</InputLabel>
-              <OutlinedInput
-                type={showPassword ? 'text' : 'password'}
-                endAdornment={
-                  <InputAdornment position="end">
-                    <IconButton
-                      aria-label="toggle password visibility"
-                      onClick={handleClickShowPassword}
-                      onMouseDown={handleMouseDownPassword}
-                      edge="end"
-                    >
-                      {showPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                }
-                label="Password"
-                name="password"
-                value={password || ''}
-                onChange={changePw}
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <Container>
+          <div>
+            <Typography variant="h4">Sign up</Typography>
+            <Margin style={{ marginTop: 0 }}>
+              <TextField
+                label="ID"
+                helperText={usernameCheck ? ' ' : '영어,숫자로 4~12자'}
+                variant="outlined"
+                margin="normal"
+                fullWidth
+                size="small"
+                name="username"
+                value={username || ''}
+                onChange={changeId}
               />
-              <MyFormHelperText />
-            </FormControl>
+            </Margin>
+            <Margin style={{ marginTop: 20 }}>
+              <FormControl variant="outlined" fullWidth>
+                <InputLabel htmlFor="outlined-adornment-password">Password</InputLabel>
+                <OutlinedInput
+                  type={showPassword ? 'text' : 'password'}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label="toggle password visibility"
+                        onClick={handleClickShowPassword}
+                        onMouseDown={handleMouseDownPassword}
+                        edge="end"
+                      >
+                        {showPassword ? <Visibility /> : <VisibilityOff />}
+                      </IconButton>
+                    </InputAdornment>
+                  }
+                  label="Password"
+                  name="password"
+                  value={password || ''}
+                  onChange={changePw}
+                />
+                <MyFormHelperText />
+              </FormControl>
 
-            {pwSame ? (
-              <TextField
-                label="다시 한번 더 입력해주세요"
-                helperText=" "
-                size="small"
-                type="password"
-                variant="outlined"
-                margin="dense"
-                fullWidth
-                name="password2"
-                value={password2 || ''}
-                onChange={changePw2}
-              />
-            ) : (
-              <TextField
-                error
-                label="error"
-                helperText="패스워드가 일치하지않습니다"
-                size="small"
-                type="password"
-                variant="outlined"
-                margin="dense"
-                fullWidth
-                name="password2"
-                value={password2 || ''}
-                onChange={changePw2}
-              />
-            )}
-          </Margin>
-          {/* <Margin style={{ marginTop: '0' }}>
+              {pwSame ? (
+                <TextField
+                  label="다시 한번 더 입력해주세요"
+                  helperText=" "
+                  size="small"
+                  type="password"
+                  variant="outlined"
+                  margin="dense"
+                  fullWidth
+                  name="password2"
+                  value={password2 || ''}
+                  onChange={changePw2}
+                />
+              ) : (
+                <TextField
+                  error
+                  label="error"
+                  helperText="패스워드가 일치하지않습니다"
+                  size="small"
+                  type="password"
+                  variant="outlined"
+                  margin="dense"
+                  fullWidth
+                  name="password2"
+                  value={password2 || ''}
+                  onChange={changePw2}
+                />
+              )}
+            </Margin>
+            {/* <Margin style={{ marginTop: '0' }}>
             <TextField
               size="small"
               label="NickName"
@@ -221,34 +228,35 @@ const SignUp = () => {
               onChange={change}
             />
           </Margin> */}
-          <Margin>
-            <TextField
-              size="small"
-              label="Email"
-              helperText={emailCheck ? ' ' : '이메일형식(@)'}
-              variant="outlined"
-              margin="dense"
-              fullWidth
-              name="email"
-              value={email || ''}
-              onChange={changeEmail}
-            />
-          </Margin>
+            <Margin>
+              <TextField
+                size="small"
+                label="Email"
+                helperText={emailCheck ? ' ' : '이메일형식(@)'}
+                variant="outlined"
+                margin="dense"
+                fullWidth
+                name="email"
+                value={email || ''}
+                onChange={changeEmail}
+              />
+            </Margin>
 
-          <BtnWrap>
-            <div>
-              <Button variant="outlined" fullWidth onClick={goLogin}>
-                cancel
-              </Button>
-            </div>
-            <div>
-              <Button variant="outlined" fullWidth onClick={signupUser}>
-                sign up
-              </Button>
-            </div>
-          </BtnWrap>
-        </div>
-      </Container>
+            <BtnWrap>
+              <div>
+                <Button variant="outlined" fullWidth onClick={goLogin}>
+                  cancel
+                </Button>
+              </div>
+              <div>
+                <Button variant="outlined" fullWidth onClick={signupUser}>
+                  sign up
+                </Button>
+              </div>
+            </BtnWrap>
+          </div>
+        </Container>
+      )}
     </MotionContainer>
   );
 };

--- a/src/shared/AnimatedRouter.jsx
+++ b/src/shared/AnimatedRouter.jsx
@@ -8,6 +8,7 @@ import Login from '../pages/Login';
 import SignUp from '../pages/SignUp';
 import { PATH_URL } from './constants';
 import BoardCreate from '../pages/BoardCreate';
+import LoadingTest from './LoadingTest';
 
 const AnimatedRouter = () => {
   const location = useLocation();
@@ -20,6 +21,7 @@ const AnimatedRouter = () => {
         <Route path={PATH_URL.BOARD} element={<BoardList />} />
         <Route path={PATH_URL.POST} element={<BoardDetail />} />
         <Route path={PATH_URL.CREATE} element={<BoardCreate />} />
+        <Route path="/test" element={<LoadingTest />} />
       </Routes>
     </AnimatePresence>
   );

--- a/src/shared/LoadingTest.jsx
+++ b/src/shared/LoadingTest.jsx
@@ -1,0 +1,5 @@
+import Loading from '../component/Loading';
+
+export default function LoadingTest() {
+  return <Loading />;
+}


### PR DESCRIPTION
## 개요
- 로그아웃 상태 시 상세 게시물 접근할 수 없는 오류 수정
- loading spinner 적용
- 서버에서 가져온 img가 깨질 경우 no-img 처리
- 중복되는 이미지 컴포넌트 분리
## 작업 사항
- **[src/component/board/Detail.jsx]**
  - `tokenUsername = jwtDecode(token);` 코드 때문에 토큰이 없는 사용자가 게시글 상세 페이지에 접근할 경우 crushed 되는 오류가 존재하여 token이 있을 경우 해당 코드가 실행되도록 조건 부여
- img 태그의 `onError` 속성을 부여해 서버에서 게시글 데이터를 불러올 때 깨지는 이미지가 있을 경우  no-img로 대체
- **[src/component/common/ImgTag.jsx]**
  - 중복되는 img 태그 컴포넌트로 분리
- 로그인, 회원가입 성공 시, 게시글 페이지, 게시글 상세 페이지 진입 시 Loading spinner 적용
## 개선점
- 라우터에 연결된 LoadingTest 컴포넌트는 테스트용입니다. 추후 삭제 예정
- 로그인, 회원가입 성공 시 로딩 화면이 보인 후 다음 페이지로 navigate할 때 현재 페이지가 잠깐 보였다가 이동되는 오류가 있습니다.